### PR TITLE
Add hook to detecting missing pytest files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,15 @@
--   id: clang-format
-    name: clang-format
-    description: Format files with ClangFormat.
-    entry: ./clang-format/bin/clang-format-hook
-    language: script
-    files: \.(c|cc|cxx|cpp|h|tcc)$
+- id: clang-format
+  name: clang-format
+  description: Format files with ClangFormat.
+  entry: ./clang-format/bin/clang-format-hook
+  language: script
+  files: \.(c|cc|cxx|cpp|h|tcc)$
+
+- id: cmake-missing-pytest-files
+  name: Check for missing Pytest files
+  description: Checks for Python unit tests which will not be run in automated tests.
+  entry: cmake-missing-pytest-files
+  pass_filenames: false
+  language: python
+  additional_dependencies: [gitpython]
+  files: \.(py|txt|cmake)$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,7 +9,6 @@
   name: Check for missing Pytest files
   description: Checks for Python unit tests which will not be run in automated tests.
   entry: cmake-missing-pytest-files
-  pass_filenames: false
   language: python
   additional_dependencies: [gitpython]
-  files: \.(py|txt|cmake)$
+  types: [python]

--- a/cmake_missing_pytest_files/check_for_missing_py_tests.py
+++ b/cmake_missing_pytest_files/check_for_missing_py_tests.py
@@ -1,0 +1,80 @@
+import re
+import sys
+from pathlib import Path
+from typing import List
+
+# GitPython
+import git
+
+
+def main():
+    root = get_repo_root()
+    pytest_files = grep_pytest_files(root)
+    cmake_files = grep_cmake_files(root)
+    has_missing = compare_file_paths(cmake_files=cmake_files, pytest_files=pytest_files)
+    if has_missing:
+        sys.exit(1)  # Exit with non-zero for CI
+
+
+def get_repo_root():
+    return git.Repo("", search_parent_directories=True)
+
+
+def grep_pytest_files(repo: git.Repo) -> List[str]:
+    # CMake enforces all pytest files use unittest.main(), so let's use this as our marker
+    pytest_file_marker = "unittest.main()"
+    git_command = ["git", "grep", "--files-with-matches", pytest_file_marker]
+    pytest_file_names: str = repo.git.execute(git_command)
+    full_filename_paths = pytest_file_names.split("\n")
+    return _get_file_name(full_filename_paths)
+
+
+def _get_file_name(file_paths: List[str]):
+    full_file_paths = [i for i in file_paths if ".py".casefold() in i.casefold()]
+    full_file_paths = [i.strip() for i in full_file_paths]
+    # Replace any rogue ( or ) chars
+    full_file_paths = [i.replace(')', '').replace('(', '') for i in full_file_paths]
+    return [Path(file).name for file in full_file_paths]
+
+
+def _parse_py_filenames_from_cmake(repo_root: Path, file_path: str):
+    if "mantidqt" in file_path:
+        foo = 2
+
+    cmake_file = repo_root / file_path
+    with open(cmake_file.resolve(strict=True), 'r') as handle:
+        raw_file_text: str = handle.read()
+    # Use *.py as the file indicator - where \S+ is 1-n non whitespace chars
+    file_lines = re.findall(r"\S+\.py", raw_file_text, flags=re.IGNORECASE)
+    return _get_file_name(file_lines)
+
+
+def grep_cmake_files(repo: git.Repo) -> List[str]:
+    cmake_file_marker = "pyunittest_add_test"
+    git_command = ["git", "grep", "--files-with-matches", cmake_file_marker]
+    cmake_file_names: str = repo.git.execute(git_command)
+
+    file_names = []
+    git_dir = Path(repo.working_tree_dir)
+    for cmake_file in cmake_file_names.split("\n"):
+        file_names.extend(_parse_py_filenames_from_cmake(git_dir, cmake_file))
+    return file_names
+
+
+def compare_file_paths(cmake_files: List[str], pytest_files: List[str]) -> bool:
+    todo_remove = sorted(cmake_files, key=str.casefold)
+
+    cmake_set = set(cmake_files)
+    pytest_set = set(pytest_files)
+    difference = pytest_set - cmake_set
+    if len(difference) > 0:
+        warning_str = "The following Pytest files are missing from CMakeLists, and will not be run:\n"
+        sorted_list = sorted(list(difference), key=str.casefold)
+        for missing_name in sorted_list:
+            warning_str += missing_name + '\n'
+        print(warning_str, file=sys.stderr)
+    return len(difference) > 0
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,17 @@
+[metadata]
+name = mantid_pre_commit_hooks
+version = 1.0.0
+description = Various Mantid Pre-commit hooks
+
+[options]
+packages = find:
+install_requires =
+    gitpython
+
+[options.packages.find]
+exclude =
+    clang-format
+
+[options.entry_points]
+console_scripts =
+    cmake-missing-pytest-files = cmake_missing_pytest_files.check_for_missing_py_tests:main

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
Adds a new hook which will detect any files which are missing from our
CMake lists, but exist as unit test files.

This is a common bug with many tests skipped in our CI because they are
missed