### PR TITLE
Fix clang-format hook on Linux

### DIFF
--- a/clang-format/bin/clang-format-hook
+++ b/clang-format/bin/clang-format-hook
@@ -11,4 +11,4 @@ else
 fi
 
 BASEDIR=$(dirname $0)
-$PYTHON_EXE "$BASEDIR/clang-format-hook.py" $1
+$PYTHON_EXE "$BASEDIR/clang-format-hook.py" "$@"


### PR DESCRIPTION
Pre-commit passes a variable number of args to batch up processing.
Currently we are forwarding the first and discarding the rest.