### PR TITLE
Handle unusual unicode characters in py test files

### DIFF
--- a/cmake_missing_pytest_files/check_for_missing_py_tests.py
+++ b/cmake_missing_pytest_files/check_for_missing_py_tests.py
@@ -31,7 +31,7 @@ def grep_pytest_files(filenames: Iterable[str]) -> List[str]:
     pytest_file_marker = "unittest.main()"
     pytest_files = []
     for filename in filenames:
-        with open(filename, 'r') as handle:
+        with open(filename, 'r', encoding="utf-8") as handle:
             is_unit_test_file = pytest_file_marker in handle.read()
         if is_unit_test_file:
             pytest_files.append(filename)


### PR DESCRIPTION
eg in test_projectparser_mantidplot.py:

```
        self.assertEqual(axes_dict[0]["yAxisTitle"], "Counts (μs)⁻¹")
```

Was causing check on missing py test files to fail on Windows